### PR TITLE
Admin repair shop page & show shops in winner page

### DIFF
--- a/ClientApp/src/AppRoutes.js
+++ b/ClientApp/src/AppRoutes.js
@@ -19,78 +19,84 @@ import { DetailedItemInfoPage } from "./components/DetailedItemInfoPage/Detailed
 import ItemCreationPage from "./components/ItemCreation/ItemCreationPage";
 import { ItemWinnerViewPage } from "./components/ItemWinnerViewPage/ItemWinnerViewPage";
 
+import { AdminRepairShopListPage } from "./components/AdminRepairShopListPage/AdminRepairShopListPage";
+
 const AppRoutes = [
-  {
-    path: '/apie-mus',
-    element: <AboutUs />
-  },
-  {
-    path: '/prisijungimas',
-    element: <LoginPage />
-  },
-  {
-    index: true,
-    element: <HomePage />
-  },
-  {
-    path: '/registracija',
-    element: <RegistrationPage />
-  },
-  {
-  path: '/pamirsau-slaptazodi',
-  element: <ForgotPasswordPage />
-  },
-  {
-  path: '/pagalba',
-  element: <HelpPage />
-  },
-  {
-    path: '/profile',
-    element: <ProfilePage />
-  },
-  {
-    path: '/pamirsau-slaptazodi',
-    element: <ForgotPasswordPage />
-  },
-  {
-      path: '/skelbimas/:itemId',
-      element: <ItemViewPage />
-  },
-  {
-      path: '/skelbimas/redaguoti/:itemId',
-      element: <ItemUpdatePage />
-  },
-  {
-      path: '/skelbimas/naujas',
-      element: <ItemCreationPage />
-  },
-  {
-      path: '/skelbimas/detailedItem/:itemId',
-      element: <DetailedItemInfoPage />
-  },
-  {
-    path: '/search/:searchQuery',
-    element: <SearchResultsPage />
-  },
-  {
-    path: '/search/category/:categoryId',
-    element: <SearchResultsByCategoryPage />
-  },
-  {
-    path: '/changepassword',
-    element: <ChangePasswordPage />
-  },
-  {
-      path: '/verifyemail',
-      element: <VerifyEmailPage />
-  },
-  {
-    path: '/taisykla/nauja',
-    element: <RepairShopCreationPage />
-  },
-   {
-      path: '/laimejimas/:itemId',
-      element: <ItemWinnerViewPage />
-  }
+    {
+        path: '/apie-mus',
+        element: <AboutUs />
+    },
+    {
+        path: '/prisijungimas',
+        element: <LoginPage />
+    },
+    {
+        index: true,
+        element: <HomePage />
+    },
+    {
+        path: '/registracija',
+        element: <RegistrationPage />
+    },
+    {
+        path: '/pamirsau-slaptazodi',
+        element: <ForgotPasswordPage />
+    },
+    {
+        path: '/pagalba',
+        element: <HelpPage />
+    },
+    {
+        path: '/profile',
+        element: <ProfilePage />
+    },
+    {
+        path: '/pamirsau-slaptazodi',
+        element: <ForgotPasswordPage />
+    },
+    {
+        path: '/skelbimas/:itemId',
+        element: <ItemViewPage />
+    },
+    {
+        path: '/skelbimas/redaguoti/:itemId',
+        element: <ItemUpdatePage />
+    },
+    {
+        path: '/skelbimas/naujas',
+        element: <ItemCreationPage />
+    },
+    {
+        path: '/skelbimas/detailedItem/:itemId',
+        element: <DetailedItemInfoPage />
+    },
+    {
+        path: '/search/:searchQuery',
+        element: <SearchResultsPage />
+    },
+    {
+        path: '/search/category/:categoryId',
+        element: <SearchResultsByCategoryPage />
+    },
+    {
+        path: '/changepassword',
+        element: <ChangePasswordPage />
+    },
+    {
+        path: '/verifyemail',
+        element: <VerifyEmailPage />
+    },
+    {
+        path: '/taisykla/nauja',
+        element: <RepairShopCreationPage />
+    },
+    {
+        path: '/laimejimas/:itemId',
+        element: <ItemWinnerViewPage />
+    },
+    {
+        path: '/admin/taisyklos',
+        element: <AdminRepairShopListPage />
+    }
 ];
 export default AppRoutes;

--- a/ClientApp/src/components/AdminRepairShopListPage/AdminRepairShopListPage.css
+++ b/ClientApp/src/components/AdminRepairShopListPage/AdminRepairShopListPage.css
@@ -1,0 +1,10 @@
+﻿.outerBoxWrapper {
+    padding-top: 80px;
+    padding-bottom: 80px;
+}
+
+hr {
+    margin-top: 5%;
+    margin-bottom: 5%;
+    border: grey solid 1px;
+}

--- a/ClientApp/src/components/AdminRepairShopListPage/AdminRepairShopListPage.js
+++ b/ClientApp/src/components/AdminRepairShopListPage/AdminRepairShopListPage.js
@@ -1,0 +1,82 @@
+﻿import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Col, Container, Row, Form, Button, Card, Spinner } from 'react-bootstrap';
+import toast, { Toaster } from 'react-hot-toast';
+import './AdminRepairShopListPage.css'
+import axios from 'axios';
+
+export const AdminRepairShopListPage = () => {
+    const [canAccess, setCanAccess] = useState(null);
+    const [repairShopList, setRepairShopList] = useState([]);
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        const fetchCanAccess = async () => {
+            try {
+                const response = await axios.get('api/user/isLoggedIn/1');
+
+                if (response.status === 200) {
+                    setCanAccess(true);
+                } else {
+                    toast('Neturite prieigos prie šio puslapio!')
+                    navigate('/');
+                }
+            } catch (error) {
+                if (error.response.status === 401) {
+                    navigate('/prisijungimas');
+                    toast('Turite būti prisijungęs!');
+                }
+                else {
+                    navigate('/index');
+                    toast('Įvyko klaida, susisiekite su administratoriumi!');
+                }
+            }
+        };
+        fetchCanAccess();
+    });
+
+    useEffect(() => {
+        const fetchRepairShops = async () => {
+            try {
+                const response = await axios.get('api/repairshop/getRepairShops');
+                setRepairShopList(response.data);
+                console.log(response.data);
+            } catch (error) {
+                toast('Įvyko klaida, susisiekite su administratoriumi!');
+            }
+        };
+        fetchRepairShops();
+    }, [canAccess]);
+
+    const handleSubmit = (event) => {
+        event.preventDefault();
+
+        axios.post('api/item/submitWinnerDetails')
+            .then(response => {
+                if (response.data) {
+                    toast('Sėkmingai išsiųstas pranešimas skelbėjui!');
+                }
+                else {
+                    toast('Įvyko klaida, susisiekite su administratoriumi!');
+                }
+            })
+            .catch(error => {
+                toast('Įvyko klaida, susisiekite su administratoriumi!');
+            });
+    };
+
+    return canAccess && repairShopList ? (
+        <div className='outerBoxWrapper'>
+            <Toaster />
+            <Container className="my-5">
+                
+            </Container>
+        </div>
+    ) : (
+        <Container className="my-5">
+            <div className='outerBoxWrapper d-flex justify-content-center'>
+                <Spinner animation="border" role="status" />
+            </div>
+        </Container>
+    );
+}

--- a/ClientApp/src/components/AdminRepairShopListPage/AdminRepairShopListPage.js
+++ b/ClientApp/src/components/AdminRepairShopListPage/AdminRepairShopListPage.js
@@ -7,7 +7,7 @@ import axios from 'axios';
 
 export const AdminRepairShopListPage = () => {
     const [canAccess, setCanAccess] = useState(null);
-    const [repairShopList, setRepairShopList] = useState([]);
+    const [repairShopList, setRepairShopList] = useState(null);
     const navigate = useNavigate();
 
     useEffect(() => {
@@ -22,13 +22,13 @@ export const AdminRepairShopListPage = () => {
                     navigate('/');
                 }
             } catch (error) {
-                if (error.response.status === 401) {
-                    navigate('/prisijungimas');
-                    toast.error('Turite būti prisijungęs!');
+                if (error.response.status !== 401) {
+                    navigate('/');
+                    toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                 }
                 else {
-                    navigate('/index');
-                    toast.error('Įvyko klaida, susisiekite su administratoriumi!');
+                    toast.error('Neturite prieigos prie šio puslapio!')
+                    navigate('/');
                 }
             }
         };
@@ -44,7 +44,9 @@ export const AdminRepairShopListPage = () => {
                 toast.error('Įvyko klaida, susisiekite su administratoriumi!');
             }
         };
-        fetchRepairShops();
+        if (canAccess) {
+            fetchRepairShops();
+        }
     }, [canAccess]);
 
     const handleSubmit = (event, index) => {
@@ -78,6 +80,7 @@ export const AdminRepairShopListPage = () => {
         <div className='outerBoxWrapper'>
             <Toaster />
             <Container className='my-5'>
+                <h3 style={{ textAlign: "center", marginBottom: "50px" }}>Taisyklų reklamų sąrašas</h3>
                 <Table striped bordered hover>
                     <thead>
                         <tr>

--- a/ClientApp/src/components/ChangePasswordPage/ChangePasswordPage.js
+++ b/ClientApp/src/components/ChangePasswordPage/ChangePasswordPage.js
@@ -55,34 +55,20 @@ const ChangePasswordPage = () => {
             fetch("api/user/changePassword", requestOptions)
                 .then(response => {
                     if (response.status === 200) {
-                        toast('Slaptažodis sėkmingai pakeistas!');
+                        toast.success('Slaptažodis sėkmingai pakeistas!');
                         navigate("/prisijungimas");
                     }
                     else if (response.status === 401) {
-                        toast("Neteisingi nuorodos duomenys. Pakartokite slaptažodžio pakeitimo užklausą.", {
-                            style: {
-                                backgroundColor: 'red',
-                                color: 'white',
-                            },
-                        });
+                        toast.error("Neteisingi nuorodos duomenys. Pakartokite slaptažodžio pakeitimo užklausą.");
                     }
                     else if (response.status === 300) {
-                        toast("Pasibaigė laikotarpios pakeisti slaptažodžiui. Pakartokite slaptažodžio pakeitimo užklausą.", {
-                            style: {
-                                backgroundColor: 'red',
-                                color: 'white',
-                            },
-                        });
+                        toast.error("Pasibaigė laikotarpios pakeisti slaptažodžiui. Pakartokite slaptažodžio pakeitimo užklausą.")
                     }
                     else {
-                        toast("Įvyko klaida, susisiekite su administratoriumi!", {
-                            style: {
-                                backgroundColor: 'red',
-                                color: 'white',
-                            },
-                        });
+                        toast.error("Įvyko klaida, susisiekite su administratoriumi!");
+                    }
                 }
-            })
+            );
         }
     }
 

--- a/ClientApp/src/components/DetailedItemInfoPage/DetailedItemInfoPage.js
+++ b/ClientApp/src/components/DetailedItemInfoPage/DetailedItemInfoPage.js
@@ -24,7 +24,7 @@ export const DetailedItemInfoPage = () => {
                 setItem(response.data);
 
             } catch (error) {
-                toast('Įvyko klaida, susisiekite su administratoriumi!');
+                toast.error('Įvyko klaida, susisiekite su administratoriumi!');
             }
         };
 
@@ -43,7 +43,7 @@ export const DetailedItemInfoPage = () => {
                     setIsLoggedInAsAdmin(false);
                 }
                 else {
-                    toast('Įvyko klaida, susisiekite su administratoriumi!');
+                    toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                 }
             }
         };
@@ -58,10 +58,10 @@ export const DetailedItemInfoPage = () => {
             } catch (error) {
                 if (error.response.status === 401) {
                     navigate('/prisijungimas');
-                    toast('Turite būti prisijungęs!');
+                    toast.error('Turite būti prisijungęs!');
                 }
                 else {
-                    toast('Įvyko klaida, susisiekite su administratoriumi!');
+                    toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                 }
             }
         };
@@ -87,7 +87,7 @@ export const DetailedItemInfoPage = () => {
                 const response = await axios.get(`api/item/getQuestionsAndAnswers/${itemId}`);
                 setItemQuestions_Answers(response.data);
             } catch (error) {
-                toast('Įvyko klaida, susisiekite su administratoriumi!');
+                toast.error('Įvyko klaida, susisiekite su administratoriumi!');
             }
         };
 
@@ -100,7 +100,7 @@ export const DetailedItemInfoPage = () => {
                  const response = await axios.get(`api/item/getOffers/${itemId}`);
                  setItemOffers(response.data);
              } catch (error) {
-                 toast('Įvyko klaida, susisiekite su administratoriumi!');
+                 toast.error('Įvyko klaida, susisiekite su administratoriumi!');
              }
          };
     
@@ -115,7 +115,7 @@ export const DetailedItemInfoPage = () => {
                     setItemLotteryParticipants(response.data);
                     console.log(response.data);
                 } catch (error) {
-                    toast('Įvyko klaida, susisiekite su administratoriumi!');
+                    toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                 }
             };
     
@@ -132,19 +132,19 @@ export const DetailedItemInfoPage = () => {
             await axios.post(`/api/item/chooseQuestionnaireWinner`, requestBody)
             .then(response => {
                 if (response) {
-                    toast('Išsirinkote, kam padovanoti! Laimėtojui išsiųstas el. laiškas dėl susisiekimo.');
+                    toast.success('Išsirinkote, kam padovanoti! Laimėtojui išsiųstas el. laiškas dėl susisiekimo.');
                     navigate(`/`);
                 }
                 else {
-                    toast('Įvyko klaida, susisiekite su administratoriumi!');
+                    toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                 }
             })
             .catch(error => {
                 if (error.response.status === 401) {
-                    toast('Turite būti prisijungęs!');
+                    toast.success('Turite būti prisijungęs!');
                 }
                 else {
-                    toast('Įvyko klaida, susisiekite su administratoriumi!');   
+                    toast.error('Įvyko klaida, susisiekite su administratoriumi!');   
                 }
             });
             setSubmitting(false);
@@ -162,20 +162,20 @@ export const DetailedItemInfoPage = () => {
         await axios.post(`/api/item/chooseOfferWinner`, requestBody)
             .then(response => {
                 if (response) {
-                    toast('Išsirinkote, su kuo mainyti! Laimėtojui išsiųstas el. laiškas dėl susisiekimo.');
+                    toast.success('Išsirinkote, su kuo mainyti! Laimėtojui išsiųstas el. laiškas dėl susisiekimo.');
                     navigate(`/`);
                 }
                 else {
-                    toast('Įvyko klaida, susisiekite su administratoriumi!');
+                    toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                 }
             })
             .catch(error => {
                 if (error.response.status === 401) {
-                    toast('Turite būti prisijungęs!');
+                    toast.error('Turite būti prisijungęs!');
                 }
                 else {
                     console.log(error);
-                    toast('Įvyko klaida, susisiekite su administratoriumi!');
+                    toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                 }
             });
         setSubmitting(false);

--- a/ClientApp/src/components/ForgotPasswordPage/ForgotPasswordPage.js
+++ b/ClientApp/src/components/ForgotPasswordPage/ForgotPasswordPage.js
@@ -21,34 +21,19 @@ const ForgotPasswordPage = () => {
             .then(response => {
                 setIsSubmitting(false);
                 if (response.status === 200) {
-                    toast('Nuoroda į slaptažodžio pakeitimą sėkmingai išsiųsta.');
+                    toast.success('Nuoroda į slaptažodžio pakeitimą sėkmingai išsiųsta.');
                 }
                 else if (response.status === 404) {
-                    toast("Nerastas vartotojas su pateiktais duomenimis!", {
-                        style: {
-                            backgroundColor: 'red',
-                            color: 'white',
-                        },
-                    });
+                    toast.error("Nerastas vartotojas su pateiktais duomenimis!");
                 }
                 else if (response.status === 401) {
-                    toast("Klaida išsiunčiant pakeitimo žinutę. Bandykite dar kartą.", {
-                        style: {
-                            backgroundColor: 'red',
-                            color: 'white',
-                        },
-                    });
+                    toast.error("Klaida išsiunčiant pakeitimo žinutę. Bandykite dar kartą.");
                 }
                 else {
-                    toast("Įvyko klaida, susisiekite su administratoriumi!", {
-                        style: {
-                            backgroundColor: 'red',
-                            color: 'white',
-                        },
-                    });
+                    toast.error("Įvyko klaida, susisiekite su administratoriumi!");
                 }
-
-            })
+            }
+        );
     }
 
     return (

--- a/ClientApp/src/components/ItemCreation/ItemCreationPage.js
+++ b/ClientApp/src/components/ItemCreation/ItemCreationPage.js
@@ -58,14 +58,14 @@ const ItemCreationPage = () => {
             })
             .catch(error => {
                 console.log(error);
-                toast("Įvyko klaida, susisiekite su administratoriumi!");
+                toast.error("Įvyko klaida, susisiekite su administratoriumi!");
             });
     }, []);
 
     useEffect(() => {
         if (images.length < 1) return;
         if (images.length > 6) {
-            toast("Negalima įkelti daugiau nei 6 nuotraukų!", {
+            toast.error("Negalima įkelti daugiau nei 6 nuotraukų!", {
                 style: {
                     backgroundColor: 'red',
                     color: 'white',
@@ -82,7 +82,7 @@ const ItemCreationPage = () => {
             });
         }
         catch (error) {
-            toast("Įvyko klaida, susisiekite su administratoriumi!");
+            toast.error("Įvyko klaida, susisiekite su administratoriumi!");
             console.log(error);
         }
     }
@@ -94,7 +94,7 @@ const ItemCreationPage = () => {
             });
         }
         catch (error) {
-            toast("Įvyko klaida, susisiekite su administratoriumi!");
+            toast.error("Įvyko klaida, susisiekite su administratoriumi!");
             console.log(error);
         }
     }

--- a/ClientApp/src/components/ItemUpdatePage/ItemUpdatePage.js
+++ b/ClientApp/src/components/ItemUpdatePage/ItemUpdatePage.js
@@ -27,7 +27,7 @@ function ItemUpdatePage() {
         })
         .catch(error => {
             console.log(error);
-            toast("Įvyko klaida, susisiekite su administratoriumi!");
+            toast.error("Įvyko klaida, susisiekite su administratoriumi!");
         })
 }, []);
 
@@ -45,7 +45,7 @@ useEffect(() => {
         }
         else
         {
-          toast('Įvyko klaida, susisiekite su administratoriumi!');
+          toast.error('Įvyko klaida, susisiekite su administratoriumi!');
         }
       }
   };
@@ -71,11 +71,11 @@ useEffect(() => {
         } catch (error) {
           if (error.response.status === 401) {
             navigate('/prisijungimas');
-            toast('Turite būti prisijungęs!');
+            toast.error('Turite būti prisijungęs!');
           }
           else
           {
-            toast('Įvyko klaida, susisiekite su administratoriumi!');
+            toast.error('Įvyko klaida, susisiekite su administratoriumi!');
           }
         }
     };
@@ -89,7 +89,7 @@ if (!isLoggedInAsAdmin)
 {
     if (item && viewerId && item.userId !== viewerId) {
       navigate('/');
-      toast('Jūs nesate šio skelbimo savininkas');
+      toast.error('Jūs nesate šio skelbimo savininkas');
     }
 }
 
@@ -140,7 +140,7 @@ if (!isLoggedInAsAdmin)
       navigate(`/skelbimas/${itemId}`);
     } catch (error) {
       console.log(error);
-      toast('Ivyko klaida, susisiekite su administratoriumi!');
+      toast.error('Ivyko klaida, susisiekite su administratoriumi!');
     }
   };
 
@@ -195,7 +195,7 @@ function handleDeleteImage(id) {
         });
     }
     catch (error) {
-        toast("Įvyko klaida, susisiekite su administratoriumi!");
+        toast.error("Įvyko klaida, susisiekite su administratoriumi!");
         console.log(error);
     }
 }

--- a/ClientApp/src/components/ItemViewPage/ItemViewPage.js
+++ b/ClientApp/src/components/ItemViewPage/ItemViewPage.js
@@ -31,7 +31,7 @@ export const ItemViewPage = () => {
                 }, 1000);
 
             } catch (error) {
-                toast('Įvyko klaida, susisiekite su administratoriumi!');
+                toast.error('Įvyko klaida, susisiekite su administratoriumi!');
             }
         };
 
@@ -51,7 +51,7 @@ export const ItemViewPage = () => {
                     const response = await axios.get('api/item/getUserItems');
                     setUserItems(response.data);
                 } catch (error) {
-                    //toast('Įvyko klaida, susisiekite su administratoriumi!');
+                    //toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                 }
             };
             fetchUserItems();
@@ -62,7 +62,7 @@ export const ItemViewPage = () => {
                     const response = await axios.get(`api/item/isUserParticipatingInLottery/${itemId}`);
                     setIsUserParticipating(response.data);
                 } catch (error) {
-                    //toast('Įvyko klaida, susisiekite su administratoriumi!');
+                    //toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                 }
             };
             fetchIsUserParticipating();
@@ -75,7 +75,7 @@ export const ItemViewPage = () => {
                 const response = await axios.get('api/user/getCurrentUserId');
                 setViewerId(response.data);
             } catch (error) {
-                //toast('Įvyko klaida, susisiekite su administratoriumi!');
+                //toast.error('Įvyko klaida, susisiekite su administratoriumi!');
             }
         };
         fetchViewerId();
@@ -93,7 +93,7 @@ export const ItemViewPage = () => {
                     setIsLoggedInAsAdmin(false);
                 }
                 else {
-                    toast('Įvyko klaida, susisiekite su administratoriumi!');
+                    toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                 }
             }
         };
@@ -119,14 +119,14 @@ export const ItemViewPage = () => {
         event.preventDefault();
 
         if (item.type === 'Keitimas' && !selectedItem) {
-            toast('Pasirinkite skelbimą, kurį norite pasiūlyti keitimui.');
+            toast.error('Pasirinkite skelbimą, kurį norite pasiūlyti keitimui.');
             return;
         }
         else if (item.type === 'Klausimynas') {
             const unansweredQuestions = item.questions.filter(q => !answers[q.id]);
 
             if (unansweredQuestions.length > 0) {
-                toast('Atsakykite į visus klausimus.');
+                toast.error('Atsakykite į visus klausimus.');
                 return;
             }
         }
@@ -142,7 +142,7 @@ export const ItemViewPage = () => {
                 axios.post(`api/item/enterLottery/${itemId}`, data)
                     .then(response => {
                         if (response.data) {
-                            toast('Sėkmingai prisijungėte prie loterijos!');
+                            toast.success('Sėkmingai prisijungėte prie loterijos!');
 
                             setIsUserParticipating(true);
                             setItem({
@@ -151,15 +151,15 @@ export const ItemViewPage = () => {
                             });
                         }
                         else {
-                            toast('Įvyko klaida, susisiekite su administratoriumi!');
+                            toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                         }
                     })
                     .catch(error => {
                         if (error.response.status === 401) {
-                            toast('Turite būti prisijungęs!');
+                            toast.error('Turite būti prisijungęs!');
                         }
                         else {
-                            toast('Įvyko klaida, susisiekite su administratoriumi!');
+                            toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                         }
                     });
             }
@@ -167,7 +167,7 @@ export const ItemViewPage = () => {
                 axios.post(`api/item/leaveLottery/${itemId}`, data)
                     .then(response => {
                         if (response.data) {
-                            toast('Sėkmingai nebedalyvaujate loterijoje!');
+                            toast.success('Sėkmingai nebedalyvaujate loterijoje!');
 
                             setIsUserParticipating(false);
                             setItem({
@@ -176,15 +176,15 @@ export const ItemViewPage = () => {
                             });
                         }
                         else {
-                            toast('Įvyko klaida, susisiekite su administratoriumi!');
+                            toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                         }
                     })
                     .catch(error => {
                         if (error.response.status === 401) {
-                            toast('Turite būti prisijungęs!');
+                            toast.error('Turite būti prisijungęs!');
                         }
                         else {
-                            toast('Įvyko klaida, susisiekite su administratoriumi!');
+                            toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                         }
                     });
             }
@@ -194,7 +194,7 @@ export const ItemViewPage = () => {
             axios.post(`api/item/submitAnswers/${itemId}`, answersList)
                 .then(response => {
                     if (response.data) {
-                        toast('Sėkmingai atsakėte į klausimus!');
+                        toast.success('Sėkmingai atsakėte į klausimus!');
 
                         setIsUserParticipating(true);
                         setItem({
@@ -203,15 +203,15 @@ export const ItemViewPage = () => {
                         });
                     }
                     else {
-                        toast('Įvyko klaida, susisiekite su administratoriumi!');
+                        toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                     }
                 })
                 .catch(error => {
                     if (error.response.status === 401) {
-                        toast('Turite būti prisijungęs!');
+                        toast.error('Turite būti prisijungęs!');
                     }
                     else {
-                        toast('Įvyko klaida, susisiekite su administratoriumi!');
+                        toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                     }
                 });
         }
@@ -223,7 +223,7 @@ export const ItemViewPage = () => {
             axios.post(`api/item/submitOffer/${itemId}`, formData)
                 .then(response => {
                     if (response.data) {
-                        toast('Jūsų pasiūlymas sėkmingai išsiųstas!');
+                        toast.success('Jūsų pasiūlymas sėkmingai išsiųstas!');
 
                         setItem({
                             ...item,
@@ -231,15 +231,15 @@ export const ItemViewPage = () => {
                         });
                     }
                     else {
-                        toast('Įvyko klaida, susisiekite su administratoriumi!');
+                        toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                     }
                 })
                 .catch(error => {
                     if (error.response.status === 401) {
-                        toast('Turite būti prisijungęs!');
+                        toast.error('Turite būti prisijungęs!');
                     }
                     else {
-                        toast('Įvyko klaida, susisiekite su administratoriumi!');
+                        toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                     }
                 });
         }

--- a/ClientApp/src/components/ItemWinnerViewPage/ItemWinnerViewPage.js
+++ b/ClientApp/src/components/ItemWinnerViewPage/ItemWinnerViewPage.js
@@ -162,8 +162,9 @@ export const ItemWinnerViewPage = () => {
                                                     {shop.name} - {shop.address}, {shop.city}, {shop.phone_number}
                                                 </li>
                                             ))}
-                                    <hr></hr>
-                                    </ul></div>
+                                        </ul>
+                                        <hr></hr>
+                                    </div>
                                 ) : null }
                                 <Card.Text>Norint suderinti atsiėmimą ar pristatymą, pateikite savo kontaktinius duomenis, su kuriais skelbėjas galės su Jumis susisiekti:</Card.Text>
                                 <Form onSubmit={handleSubmit}>

--- a/ClientApp/src/components/ItemWinnerViewPage/ItemWinnerViewPage.js
+++ b/ClientApp/src/components/ItemWinnerViewPage/ItemWinnerViewPage.js
@@ -30,11 +30,11 @@ export const ItemWinnerViewPage = () => {
             } catch (error) {
                 if (error.response.status === 401) {
                     navigate('/prisijungimas');
-                    toast('Turite būti prisijungęs!');
+                    toast.error('Turite būti prisijungęs!');
                 }
                 else {
                     navigate('/index');
-                    toast('Įvyko klaida, susisiekite su administratoriumi!');
+                    toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                 }
             }
         };
@@ -47,7 +47,7 @@ export const ItemWinnerViewPage = () => {
                 const response = await axios.get(`api/item/getItem/${itemId}`);
                 setItem(response.data);
             } catch (error) {
-                toast('Įvyko klaida, susisiekite su administratoriumi!');
+                toast.error('Įvyko klaida, susisiekite su administratoriumi!');
             }
         };
         fetchItem();
@@ -59,7 +59,7 @@ export const ItemWinnerViewPage = () => {
                 const response = await axios.get(`api/user/getUserEmail/${item.userId}`);
                 setPosterEmail(response.data);
             } catch (error) {
-                toast('Įvyko klaida, susisiekite su administratoriumi!');
+                toast.error('Įvyko klaida, susisiekite su administratoriumi!');
             }
         };
         if (item && item.userId) {
@@ -79,7 +79,7 @@ export const ItemWinnerViewPage = () => {
         event.preventDefault();
 
         if (phone.length < 9) {
-            toast('Įveskite telefono numerį!');
+            toast.error('Įveskite telefono numerį!');
             return;
         }
 
@@ -96,15 +96,15 @@ export const ItemWinnerViewPage = () => {
         axios.post('api/item/submitWinnerDetails', data)
             .then(response => {
                 if (response.data) {
-                    toast('Sėkmingai išsiųstas pranešimas skelbėjui!');
+                    toast.success('Sėkmingai išsiųstas pranešimas skelbėjui!');
                 }
                 else {
-                    toast('Įvyko klaida, susisiekite su administratoriumi!');
+                    toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                     setSending(false);
                 }
             })
             .catch(error => {
-                toast('Įvyko klaida, susisiekite su administratoriumi!');
+                toast.error('Įvyko klaida, susisiekite su administratoriumi!');
                 setSending(false);
             });
     };

--- a/ClientApp/src/components/ItemWinnerViewPage/ItemWinnerViewPage.js
+++ b/ClientApp/src/components/ItemWinnerViewPage/ItemWinnerViewPage.js
@@ -29,7 +29,7 @@ export const ItemWinnerViewPage = () => {
                 }
             } catch (error) {
                 if (error.response.status === 401) {
-                    navigate('/login');
+                    navigate('/prisijungimas');
                     toast('Turite būti prisijungęs!');
                 }
                 else {

--- a/ClientApp/src/components/ItemWinnerViewPage/ItemWinnerViewPage.js
+++ b/ClientApp/src/components/ItemWinnerViewPage/ItemWinnerViewPage.js
@@ -13,6 +13,7 @@ export const ItemWinnerViewPage = () => {
     const [message, setMessage] = useState('');
     const [item, setItem] = useState(null);
     const [posterEmail, setPosterEmail] = useState(null);
+    const [repairShopList, setRepairShopList] = useState(null);
     const [sending, setSending] = useState(false);
     const navigate = useNavigate();
 
@@ -67,6 +68,20 @@ export const ItemWinnerViewPage = () => {
         }
     }, [item]);
 
+    useEffect(() => {
+        const fetchRepairShops = async () => {
+            try {
+                const response = await axios.get('api/repairshop/getRepairShops');
+                setRepairShopList(response.data);
+            } catch (error) {
+                toast.error('Įvyko klaida, susisiekite su administratoriumi!');
+            }
+        };
+        if (canAccess) {
+            fetchRepairShops();
+        }
+    }, [canAccess]);
+
     const handleMessageChange = (event) => {
         setMessage(event.target.value);
     };
@@ -109,7 +124,7 @@ export const ItemWinnerViewPage = () => {
             });
     };
 
-    return item && viewerId && canAccess && posterEmail ? (
+    return item && viewerId && canAccess && posterEmail && repairShopList ? (
         <div className='outerBoxWrapper'>
             <Toaster />
             <Container className="my-5">
@@ -137,6 +152,19 @@ export const ItemWinnerViewPage = () => {
                                 <Card.Title>Laimėjote: {item.name}</Card.Title>
                                 <Card.Text>{item.description}</Card.Text>
                                 <hr></hr>
+                                {repairShopList.filter(shop => shop.approved).length > 0 ? (
+                                    <div><Card.Text>Jeigu įrenginys turi defektą, susisiekite su vienu iš mūsų rekomenduojamų patikimų taisyklų:</Card.Text>
+                                    <ul>
+                                        {repairShopList
+                                            .filter(shop => shop.approved)
+                                            .map(shop => (
+                                                <li key={shop.id}>
+                                                    {shop.name} - {shop.address}, {shop.city}, {shop.phone_number}
+                                                </li>
+                                            ))}
+                                    <hr></hr>
+                                    </ul></div>
+                                ) : null }
                                 <Card.Text>Norint suderinti atsiėmimą ar pristatymą, pateikite savo kontaktinius duomenis, su kuriais skelbėjas galės su Jumis susisiekti:</Card.Text>
                                 <Form onSubmit={handleSubmit}>
                                     <Form.Group>

--- a/ClientApp/src/components/LoginPage/LoginPage.js
+++ b/ClientApp/src/components/LoginPage/LoginPage.js
@@ -25,7 +25,7 @@ export const LoginPage = () => {
               }
               else
               {
-                toast('Įvyko klaida, susisiekite su administratoriumi!');
+                toast.error('Įvyko klaida, susisiekite su administratoriumi!');
               }
             }
         };
@@ -49,7 +49,7 @@ export const LoginPage = () => {
                     window.location.href = "/";
                 }
                 else if (response.status === 404) {
-                    toast("Prisijungimo duomenys neteisingi!", {
+                    toast.error("Prisijungimo duomenys neteisingi!", {
                         style: {
                             backgroundColor: 'red',
                             color: 'white',
@@ -57,7 +57,7 @@ export const LoginPage = () => {
                     });
                 }
                 else if (response.status === 401) {
-                    toast("El. pašto adresas nepatvirtintas. Patikrinkite savo elektroninį paštą!", {
+                    toast.error("El. pašto adresas nepatvirtintas. Patikrinkite savo elektroninį paštą!", {
                         style: {
                             backgroundColor: 'red',
                             color: 'white',
@@ -65,7 +65,7 @@ export const LoginPage = () => {
                     });
                 }
                 else {
-                    toast("Įvyko klaida, susisiekite su administratoriumi!", {
+                    toast.error("Įvyko klaida, susisiekite su administratoriumi!", {
                         style: {
                             backgroundColor: 'red',
                             color: 'white',

--- a/ClientApp/src/components/NavMenu.css
+++ b/ClientApp/src/components/NavMenu.css
@@ -80,3 +80,7 @@ footer {
     right: 0;
     z-index: 100;
 }
+
+#nav-dropdown {
+    min-width: auto !important;
+}

--- a/ClientApp/src/components/NavMenu.js
+++ b/ClientApp/src/components/NavMenu.js
@@ -16,6 +16,7 @@ export class NavMenu extends Component {
             isClicked: false,
             isLogged: false,
             isLoggedIn: false, // Assume the user is not logged in by default
+            isLoggedInAsAdmin: false,
             dropdownOpen: false,
             selectedCategory: 'Filtras',
             userAvatar: './images/profile.png',
@@ -73,16 +74,16 @@ export class NavMenu extends Component {
           }
         
   axios.get('/api/item/search', {
-    params: {
-      searchWord: this.state.searchQuery
-    }
-  })
-  .then((response) => {
-    this.props.navigate(`/search/${this.state.searchQuery}`, { state: { searchResults: response.data, searchQuery: this.state.searchQuery } });
-  })
-  .catch((error) => {
-    console.error(error);
-  });
+        params: {
+          searchWord: this.state.searchQuery
+        }
+      })
+      .then((response) => {
+        this.props.navigate(`/search/${this.state.searchQuery}`, { state: { searchResults: response.data, searchQuery: this.state.searchQuery } });
+      })
+      .catch((error) => {
+        console.error(error);
+      });
 };
       
 getItemsByCategory(categoryId) {
@@ -105,6 +106,14 @@ getItemsByCategory(categoryId) {
                 this.setState({ isLogged: true});
             }
         })
+
+        axios.get('api/user/isLoggedIn/1')
+            .then(response => {
+                if (response.status === 200) {
+                    this.setState({ isLoggedInAsAdmin: true });
+                }
+            }
+        )
     };
 
     handleLogoutClick = () => {
@@ -114,10 +123,10 @@ getItemsByCategory(categoryId) {
                 this.setState({ isLogged: false});
             }
             else if (response.status === 401) { // 401 - Unauthorized
-                alert('Already logged out');
+                toast.error('Jūs jau esate atsijungę!');
             }
             else { // 500 - Internal server error
-                alert('Unexpected response, check console logs');
+                toast.error('Įvyko klaida, susisiekite su administratoriumi!');
             }
         })
     }
@@ -178,6 +187,9 @@ getItemsByCategory(categoryId) {
                             {this.state.isLogged ? (
                                 <NavDropdown title={<Image alt="Profilio nuotrauka" src={avatar} roundedCircle style={{ height: '75px', width: '75px' }} />} onClick={this.handleLoginClick}>
                                     <NavDropdown.Item href="/profile" onClick={this.handleClick}>Profilis</NavDropdown.Item>
+                                    {this.state.isLoggedInAsAdmin ? (
+                                        <NavDropdown.Item href="/admin/taisyklos" onClick={this.handleClick}>Taisyklos</NavDropdown.Item>
+                                    ) : null}
                                     <NavDropdown.Item href="/prisijungimas" onClick={() => { this.handleLogoutClick() }}>Atsijungti</NavDropdown.Item>
                                 </NavDropdown>
                             ) : (

--- a/ClientApp/src/components/NavMenu.js
+++ b/ClientApp/src/components/NavMenu.js
@@ -54,7 +54,7 @@ export class NavMenu extends Component {
         })
         .catch(error => {
             console.log(error);
-            toast("Įvyko klaida, susisiekite su administratoriumi!");
+            toast.error("Įvyko klaida, susisiekite su administratoriumi!");
         })
     }
     

--- a/ClientApp/src/components/ProfilePage/ProfilePage.js
+++ b/ClientApp/src/components/ProfilePage/ProfilePage.js
@@ -59,7 +59,7 @@ const ProfilePage = () => {
         const new_password = formData.get('new_password');
 
         if ((name === '' || surname === '' || email === '') && new_password === '' && old_password === '') {
-            toast('Vardas, pavardė arba el. paštas negali būti tušti!', {
+            toast.error('Vardas, pavardė arba el. paštas negali būti tušti!', {
                 style: {
                     backgroundColor: 'red',
                     color: 'white',
@@ -68,7 +68,7 @@ const ProfilePage = () => {
             return false;
         }
         else if ((new_password !== '' && old_password === '') || old_password !== '' && new_password === '') {
-            toast('Visi lauktai turi būti užpildyti norint keisti slaptažodi!', {
+            toast.error('Visi lauktai turi būti užpildyti norint keisti slaptažodi!', {
                 style: {
                     backgroundColor: 'red',
                     color: 'white',
@@ -98,7 +98,7 @@ const ProfilePage = () => {
             axios.post("api/user/updateProfileDetails", formData)
             .then(response => {
                 if (response.status === 200) {
-                    toast('Duomenys sėkmingai išsaugoti!', {
+                    toast.success('Duomenys sėkmingai išsaugoti!', {
                         style: {
                             backgroundColor: 'rgb(14, 160, 14)',
                             color: 'white',
@@ -106,20 +106,15 @@ const ProfilePage = () => {
                     });
                 }
                 else {
-                    toast("Įvyko klaida, susisiekite su administratoriumi!");
+                    toast.error("Įvyko klaida, susisiekite su administratoriumi!");
                 }
             })
             .catch(error => {
                 if (error.response.data) {
-                    toast(error.response.data, {
-                        style: {
-                            backgroundColor: 'red',
-                            color: 'white',
-                        },
-                    });
+                    toast.error(error.response.data);
                 }
                 else {
-                    toast("Įvyko klaida, susisiekite su administratoriumi!");
+                    toast.error("Įvyko klaida, susisiekite su administratoriumi!");
                 }
             });
         }

--- a/ClientApp/src/components/RegistrationPage/RegistrationPage.js
+++ b/ClientApp/src/components/RegistrationPage/RegistrationPage.js
@@ -30,7 +30,7 @@ const RegistrationPage = () => {
               }
               else
               {
-                toast('Įvyko klaida, susisiekite su administratoriumi!');
+                toast.error('Įvyko klaida, susisiekite su administratoriumi!');
               }
             }
         };
@@ -79,11 +79,11 @@ const RegistrationPage = () => {
             fetch("api/user/register", requestOptions)
                 .then(response => {
                     if (response.status === 200) {
-                        toast('Sėkmingai prisiregistravote. Elektroninio pašto patvirtinimas išsiųstas.');
+                        toast.success('Sėkmingai prisiregistravote. Elektroninio pašto patvirtinimas išsiųstas.');
                         navigate("/prisijungimas");
                     }
                     else if (response.status === 401) {
-                        toast("Nepavyko išsiųsti patvirtinimo laiško! Susisiekite su administratoriumi.", {
+                        toast.error("Nepavyko išsiųsti patvirtinimo laiško! Susisiekite su administratoriumi.", {
                             style: {
                                 backgroundColor: 'red',
                                 color: 'white',
@@ -91,7 +91,7 @@ const RegistrationPage = () => {
                         });
                     }
                     else {
-                        toast("Įvyko klaida, susisiekite su administratoriumi!", {
+                        toast.error("Įvyko klaida, susisiekite su administratoriumi!", {
                             style: {
                                 backgroundColor: 'red',
                                 color: 'white',

--- a/ClientApp/src/components/RepairShopCreationPage/RepairShopCreationPage.js
+++ b/ClientApp/src/components/RepairShopCreationPage/RepairShopCreationPage.js
@@ -19,31 +19,16 @@ const RepairShopCreationPage = () => {
     function checkFields() {
         const phoneRegex = /^(86|\+3706)/;
         if (name === '' || phone_number === '' || email === '' || address === '' || city === '' ) {
-            toast.error('Reikia užpildyti visus laukus!', {
-                style: {
-                    backgroundColor: 'red',
-                    color: 'white',
-                },
-            });
+            toast.error('Reikia užpildyti visus laukus!');
             return false;
         }
         else if (!/\S+@\S+\.\S+/.test(email)) {
-            toast.error('Įveskite teisingą el. paštą!', {
-                style: {
-                    backgroundColor: 'red',
-                    color: 'white',
-                },
-            });
+            toast.error('Įveskite teisingą el. paštą!');
             return false;
         }
         else if (!phoneRegex.test(phone_number) || phone_number.length >= 14)
         {
-            toast.error('Įveskite teisingą telefono numerį!', {
-                style: {
-                    backgroundColor: 'red',
-                    color: 'white',
-                },
-            });
+            toast.error('Įveskite teisingą telefono numerį!');
             return false;
         }
         else {
@@ -64,12 +49,7 @@ const RepairShopCreationPage = () => {
                 axios.post("api/repairshop/create", formData)
                     .then(response => {
                         if (response.status === 200) {
-                            toast.success('Sėkmingai užregistravote reklamą, su Jumis susisieks administracija dėl sekančių žingsnių!', {
-                                style: {
-                                    backgroundColor: 'rgb(14, 160, 14)',
-                                    color: 'white',
-                                },
-                            });
+                            toast.success('Sėkmingai užregistravote reklamą, su Jumis susisieks administracija dėl sekančių žingsnių!');
                             navigate(`/`)
                         }
                         else {

--- a/ClientApp/src/components/VerifyEmailPage/VerifyEmailPage.js
+++ b/ClientApp/src/components/VerifyEmailPage/VerifyEmailPage.js
@@ -26,11 +26,11 @@ const VerifyEmailPage = () => {
             fetch("api/user/verifyEmail", requestOptions)
                 .then(response => {
                     if (response.status === 200) {
-                        toast('El. pašto adresas sėkmingai patvirtintas!');
+                        toast.success('El. pašto adresas sėkmingai patvirtintas!');
                         navigate("/prisijungimas");
                     }
                     else if (response.status === 404) {
-                        toast("Neteisingi nuorodos duomenys. Bandykite iš naujo arba susisiekite su administratoriumi.", {
+                        toast.error("Neteisingi nuorodos duomenys. Bandykite iš naujo arba susisiekite su administratoriumi.", {
                             style: {
                                 backgroundColor: 'red',
                                 color: 'white',
@@ -38,7 +38,7 @@ const VerifyEmailPage = () => {
                         });
                     }
                     else {
-                        toast("Įvyko klaida, susisiekite su administratoriumi!", {
+                        toast.error("Įvyko klaida, susisiekite su administratoriumi!", {
                             style: {
                                 backgroundColor: 'red',
                                 color: 'white',

--- a/Controllers/Repair/RepairShopController.cs
+++ b/Controllers/Repair/RepairShopController.cs
@@ -2,6 +2,8 @@
 using neismesk.Models;
 using System.Data;
 using neismesk.Repositories.RepairShop;
+using neismesk.ViewModels.Repair;
+using Microsoft.AspNetCore.Authorization;
 
 namespace neismesk.Controllers.Repair
 {
@@ -40,12 +42,28 @@ namespace neismesk.Controllers.Repair
         }
 
         [HttpGet("getRepairShops")]
+        [Authorize]
         public async Task<IActionResult> GetRepairShops()
         {
             try
             {
-                List<RepairShopModel> repair_shops = await _repairShopRepo.GetRepairShops();
+                List<RepairShopViewModel> repair_shops = await _repairShopRepo.GetRepairShops();
                 return Ok(repair_shops);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        [HttpPost("changeApproval")]
+        [Authorize]
+        public async Task<IActionResult> ChangeApproval(RepairShopViewModel repairShop)
+        {
+            try
+            {
+                bool result = await _repairShopRepo.ChangeApproval(repairShop.Id, repairShop.Approved);
+                return Ok(result);
             }
             catch (Exception ex)
             {

--- a/Controllers/Repair/RepairShopController.cs
+++ b/Controllers/Repair/RepairShopController.cs
@@ -15,6 +15,7 @@ namespace neismesk.Controllers.Repair
         {
             _repairShopRepo = new RepairShopRepo();
         }
+
         [HttpPost("create")]
         public async Task<IActionResult> CreateRepairShop()
         {
@@ -32,11 +33,24 @@ namespace neismesk.Controllers.Repair
                 repair_shop.Id = await _repairShopRepo.Create(repair_shop);
                 return Ok();
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                return BadRequest();
+                return BadRequest(ex.Message);
             }
+        }
 
+        [HttpGet("getRepairShops")]
+        public async Task<IActionResult> GetRepairShops()
+        {
+            try
+            {
+                List<RepairShopModel> repair_shops = await _repairShopRepo.GetRepairShops();
+                return Ok(repair_shops);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
         }
     }
 }

--- a/Models/RepairShopModel.cs
+++ b/Models/RepairShopModel.cs
@@ -14,5 +14,7 @@
 
         public string City { get; set; }
 
+        public bool? Approved { get; set; }
+
     }
 }

--- a/Repositories/Repair/RepairShopRepo.cs
+++ b/Repositories/Repair/RepairShopRepo.cs
@@ -51,5 +51,34 @@ namespace neismesk.Repositories.RepairShop
 
             return id;
         }
+
+        public async Task<List<RepairShopModel>> GetRepairShops()
+        {
+            using MySqlConnection connection = GetConnection();
+            await connection.OpenAsync();
+
+            using MySqlCommand command = new MySqlCommand(
+                "SELECT * FROM repair_shop", connection);
+
+            List<RepairShopModel> repairShops = new List<RepairShopModel>();
+            using (DbDataReader reader = await command.ExecuteReaderAsync())
+            {
+                while (await reader.ReadAsync())
+                {
+                    RepairShopModel repairShop = new RepairShopModel()
+                    {
+                        Id = Convert.ToInt32(reader["id"]),
+                        Name = Convert.ToString(reader["name"]),
+                        Phone_number = Convert.ToString(reader["phone_number"]),
+                        Email = Convert.ToString(reader["email"]),
+                        Address = Convert.ToString(reader["address"]),
+                        City = Convert.ToString(reader["city"]),
+                        Approved = Convert.ToBoolean(reader["approved"])
+                    };
+                    repairShops.Add(repairShop);
+                }
+            }
+            return repairShops;
+        }
     }
 }

--- a/ViewModels/Repair/RepairShopViewModel.cs
+++ b/ViewModels/Repair/RepairShopViewModel.cs
@@ -4,6 +4,9 @@ namespace neismesk.ViewModels.Repair
 {
     public class RepairShopViewModel
     {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+        
         [JsonProperty("name")]
         public string Name { get; set; }
 
@@ -18,5 +21,8 @@ namespace neismesk.ViewModels.Repair
         
         [JsonProperty("city")]
 		public string City { get; set; }
+
+        [JsonProperty("approved")]
+        public bool Approved { get; set; }
     }
 }


### PR DESCRIPTION
Added a repair shop list page only accessible to admins (admin/taisyklos). Can access it by opening the profile picture dropdown when logged in as an admin.

Repair shop can be approved or deleted. Once if it is approved, it is then visible on the item winner view page:
![image](https://github.com/ItsZil/neismesk/assets/22817405/cc7c9adc-a5ab-4b82-9677-5d23042ecf0c)

Also changes all toasts to be toast.error or toast.success.